### PR TITLE
Fix mac os GitHub actions build

### DIFF
--- a/include/common/common.h
+++ b/include/common/common.h
@@ -15,3 +15,4 @@
 #include <string>
 #include <unordered_map>
 #include <set>
+#include <vector>

--- a/superbuild/opencv/CMakeLists.txt
+++ b/superbuild/opencv/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXTERNAL_DIR_INSTALL_LOCATION ${CMAKE_BINARY_DIR}/../install/)
 build_git_subproject(
   NAME opencv
   URL https://github.com/opencv/opencv.git
-  TAG 4.6.0
+  TAG 4.5.5
   BUILD_ARGS
    -DBUILD_TESTS=OFF
    -DBUILD_PERF_TESTS=OFF
@@ -32,6 +32,5 @@ build_git_subproject(
    -DBUILD_opencv_highgui=ON
    -DBUILD_WEBP=OFF
    -DWITH_WEBP=OFF
-   -DBUILD_ZLIB=OFF
    
 )


### PR DESCRIPTION
- Downgrade opencv version
- Added `#include <vector>` in common.h that was causing compiling errors on MacOs